### PR TITLE
Issue #15 - Better SSL key generation; changed default folder of ssh keys.

### DIFF
--- a/bin/veye
+++ b/bin/veye
@@ -35,7 +35,7 @@ desc 'set connection protocol'
 flag :protocol, :default_value => "http"
 
 desc 'set folder of veye_cert.pem'
-flag :ssl_path, :default_value => "~/.veye"
+flag :ssl_path, :default_value => "~/.ssh"
 
 desc "don't use colors"
 switch 'color', :default_value => true, :negetable => true

--- a/lib/veye.rb
+++ b/lib/veye.rb
@@ -1,5 +1,7 @@
 # Add requires for other files you add to your project here, so
 # you just need to require this one file in your bin file
+require 'openssl'
+
 require 'veye/version.rb'
 require 'veye/service.rb'
 require 'veye/api.rb'
@@ -71,23 +73,25 @@ end
 
 def generate_ssl_keys(global_opts)
   result = false
-  key_command = %Q[
-    openssl req -x509 -newkey rsa:2048 -keyout veye_key.pem -out veye_cert.pem -nodes
-  ]
 
   Dir.chdir(Dir.home)
   ssl_path = File.expand_path(global_opts[:ssl_path])
   unless Dir.exists?(ssl_path)
-    p "Creating folder for ssl keys: `#{ssl_path}`"
+    print "Info: Creating folder for ssl keys: `#{ssl_path}`\n"
     Dir.mkdir(ssl_path)
   end
 
   Dir.chdir(ssl_path)
-  if system(key_command)
-    print "Key is generated.\n"
+
+  key = OpenSSL::PKey::RSA.new 2048
+  open 'veye_key.pem', 'w' do |io| io.write(key.to_pem) end
+  open 'veye_cert.pem', 'w' do |io| io.write(key.public_key.to_pem) end
+
+  if ssl_key_exists?(global_opts)
+    print "Success: SSL keys are generated.\n"
     result = true
   else
-    print "Cant generate SSL keys. Do you have openssl installed?\n"
+    print "Error: Cant generate SSL keys. Do you have openssl installed?\n"
   end
 
   Dir.chdir(Dir.home)

--- a/lib/veye/api/resource.rb
+++ b/lib/veye/api/resource.rb
@@ -12,12 +12,9 @@ module Veye
         ssl_path = File.expand_path($global_options[:ssl_path])
         @resource = RestClient::Resource.new(
           @full_path,
-          :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(
-                                  File.read("#{ssl_path}/veye_cert.pem")),
-          :ssl_client_key   =>  OpenSSL::PKey::RSA.new(
-                                  File.read("#{ssl_path}/veye_key.pem"), "passphrase, if any"),
-          :ssl_ca_file      =>  "ca_certificate.pem",
-          :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER
+          :ssl_client_cert  => OpenSSL::PKey::RSA.new(File.read("#{ssl_path}/veye_cert.pem")),
+          :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read("#{ssl_path}/veye_key.pem")),
+          :verify_ssl       =>  OpenSSL::SSL::VERIFY_NONE
         )
       end
     end


### PR DESCRIPTION
fix for issue #15 .

Now, it generates proper SSL key backend and ssl keys are now stored in default `.ssh` folder.
